### PR TITLE
Fix Makefile syntax matching := and : as targets

### DIFF
--- a/runtime/syntax/makefile.yaml
+++ b/runtime/syntax/makefile.yaml
@@ -14,7 +14,8 @@ rules:
     - statement: "\\$\\((flavor|foreach|if|info|join|lastword|notdir|or)[[:space:]]"
     - statement: "\\$\\((origin|patsubst|realpath|shell|sort|strip|suffix)[[:space:]]"
     - statement: "\\$\\((value|warning|wildcard|word|wordlist|words)[[:space:]]"
-    - identifier: "^.+:"
+    - identifier: "^.+:[^=]"
+    - identifier: "^.+:$"
     - identifier: "[()$]"
     - constant.string:
         start: "\""


### PR DESCRIPTION
Before and after:
![Screenshot at 2024-01-13 01-15-53](https://github.com/petabyt/micro/assets/32369330/07e99ebc-37a3-4db6-91a5-0dbdfa9ba184)
![Screenshot at 2024-01-13 01-16-06](https://github.com/petabyt/micro/assets/32369330/d145b0e0-8197-471a-9d73-ccbc89a43fac)
